### PR TITLE
Quaternions

### DIFF
--- a/ghcjs-three.cabal
+++ b/ghcjs-three.cabal
@@ -38,6 +38,7 @@ library
                      , GHCJS.Three.Visible
                      , GHCJS.Three.Mesh
                      , GHCJS.Three.Line
+                     , GHCJS.Three.Quaternion
                      , GHCJS.Three.Ray
                      , GHCJS.Three.Raycaster
                      , GHCJS.Three.Scene
@@ -64,14 +65,14 @@ library
   default-language:    Haskell2010
   ghcjs-options:     -O2
 
-executable ghcjs-three-demo
-  hs-source-dirs:      app
-  main-is:             Main.hs
-  build-depends:       base
-                     , ghcjs-three
-                     , ghcjs-dom
-  default-language:    Haskell2010
-  ghcjs-options:      -O2 -DGHCJS_BROWSER
+-- executable ghcjs-three-demo
+--   hs-source-dirs:      app
+--   main-is:             Main.hs
+--   build-depends:       base
+--                      , ghcjs-three
+--                      , ghcjs-dom
+--   default-language:    Haskell2010
+--   ghcjs-options:      -O2 -DGHCJS_BROWSER
 
 test-suite ghcjs-three-test
   type:                exitcode-stdio-1.0

--- a/src/GHCJS/Three/HasXYZ.hs
+++ b/src/GHCJS/Three/HasXYZ.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE JavaScriptFFI #-}
 module GHCJS.Three.HasXYZ (
-    HasX(..), HasY(..), HasZ(..)
+    HasX(..), HasY(..), HasZ(..), HasW
     ) where
 
 import GHCJS.Types
@@ -24,6 +24,12 @@ foreign import javascript unsafe "($1)['z']"
 foreign import javascript unsafe "($2)['z'] = $1"
     objSetZ :: Double -> JSVal -> Three ()
 
+foreign import javascript unsafe "($1)['w']"
+    objGetW :: JSVal -> Three Double
+
+foreign import javascript unsafe "($2)['w'] = $1"
+    objSetW :: Double -> JSVal -> Three ()
+
 class (ThreeJSVal o) => HasX o where
     getX :: o -> Three Double
     getX = objGetX . toJSVal
@@ -44,3 +50,10 @@ class (ThreeJSVal o) => HasZ o where
 
     setZ :: Double -> o -> Three ()
     setZ z o = objSetZ z (toJSVal o)
+
+class (ThreeJSVal o) => HasW o where
+  getW :: o -> Three Double
+  getW = objGetW . toJSVal
+
+  setW :: Double -> o -> Three ()
+  setW w o = objSetW w (toJSVal o)

--- a/src/GHCJS/Three/Object3D.hs
+++ b/src/GHCJS/Three/Object3D.hs
@@ -14,6 +14,7 @@ import GHCJS.Three.Monad
 import GHCJS.Three.Vector
 import GHCJS.Three.Matrix
 import GHCJS.Three.Euler
+import GHCJS.Three.Quaternion
 import GHCJS.Three.GLNode
 import GHCJS.Three.Visible
 import GHCJS.Three.HasName
@@ -111,6 +112,10 @@ foreign import javascript unsafe "($2)['rotateZ']($1)"
 foreign import javascript unsafe "($3)['rotateOnAxis']($1, $2)"
     thr_rotateOnAxis :: JSVal -> Double -> JSVal -> Three ()
 
+-- | Set the rotation around an axis (which is normalized)
+foreign import javascript unsafe "($3)['setRotationFromAxisAngle']($1, $2)"
+  thr_setRotationFromAxisAngle :: JSVal -> Double -> JSVal -> Three ()
+
 -- | Gets rendered into shadow map.
 foreign import javascript unsafe "($2)['castShadow'] = $1 === 1"
     thr_setCastShadow :: Int -> JSVal -> Three ()
@@ -136,6 +141,12 @@ foreign import javascript unsafe "($1)['updateMatrixWorld']()"
 
 foreign import javascript unsafe "($2)['modelViewMatrix']['copy']($1)"
     thr_setModelViewMatrix :: JSVal -> JSVal -> Three ()
+
+foreign import javascript unsafe "($1)['quaternion']"
+    thr_quaternion :: JSVal -> Three JSVal
+
+foreign import javascript unsafe "($2)['quaternion']['copy']($1)"
+  thr_setQuaternion :: JSVal -> JSVal -> Three ()
 
 class (ThreeJSVal o) => IsObject3D o where
     getObject3D :: o -> Object3D
@@ -165,6 +176,12 @@ class (ThreeJSVal o) => IsObject3D o where
 
     setPositionOrig :: TVector3 -> o -> Three ()
     setPositionOrig p o = thr_setPosition (toJSVal p) (toJSVal o)
+
+    quaternion :: o -> Three Quaternion
+    quaternion = fmap fromJSVal . thr_quaternion . toJSVal
+
+    setQuaternion :: Quaternion -> o -> Three ()
+    setQuaternion q o = thr_setQuaternion (toJSVal q) (toJSVal o)
 
     rotation :: o -> Three TEuler
     rotation = (toTEuler . fromJSVal) <=< (thr_rotation . toJSVal)
@@ -226,6 +243,9 @@ class (ThreeJSVal o) => IsObject3D o where
 
     rotateOnAxis :: NormalVector -> Double -> o -> Three ()
     rotateOnAxis v d o = thr_rotateOnAxis (toJSVal v) d (toJSVal o)
+
+    setRotationFromAxisAngle :: NormalVector -> Double -> o -> Three ()
+    setRotationFromAxisAngle v d o = thr_setRotationFromAxisAngle (toJSVal v) d (toJSVal o)
 
     matrixWorld :: o -> Three Matrix4
     matrixWorld = fmap fromJSVal . thr_matrixWorld . toJSVal

--- a/src/GHCJS/Three/Quaternion.hs
+++ b/src/GHCJS/Three/Quaternion.hs
@@ -1,0 +1,147 @@
+{-# LANGUAGE JavaScriptFFI, GeneralizedNewtypeDeriving, MultiParamTypeClasses, FlexibleInstances, UndecidableInstances #-}
+module GHCJS.Three.Quaternion (
+    Quaternion(..),
+    mkQuaternion,
+    IsQuaternion(..)
+    ) where
+
+import Control.Monad
+import Data.Functor
+import GHCJS.Types
+import qualified GHCJS.Marshal as M
+
+import GHCJS.Three.Monad
+import GHCJS.Three.Vector
+import GHCJS.Three.Matrix
+import GHCJS.Three.Euler
+import GHCJS.Three.CanCopy
+import GHCJS.Three.HasXYZ
+
+-- | Quaternions represent rotation in 3D space
+newtype Quaternion = Quaternion {
+    getObject :: BaseObject
+} deriving (ThreeJSVal)
+
+instance CanCopy Quaternion
+instance HasX Quaternion
+instance HasY Quaternion
+instance HasZ Quaternion
+instance HasW Quaternion
+
+foreign import javascript unsafe "new window['THREE']['Quaternion']($1, $2, $3, $4)"
+    thr_mkQuaternion :: Double -> Double -> Double -> Double -> Three JSVal
+
+-- | Create a new Quaternion object from x, y, z, and w
+mkQuaternion :: Double -> Double -> Double -> Double -> Three Quaternion
+mkQuaternion x y z w = fromJSVal <$> thr_mkQuaternion x y z w
+
+class (ThreeJSVal o) => IsQuaternion o where
+  -- | Set this quaternion to describe the opposite rotation
+  conjugate :: o -> Three ()
+  conjugate = thr_conjugate . toJSVal
+
+  -- | Return the dot product of this quaternion with another
+  dot :: o -> o -> Three Double
+  dot q1 q2 = thr_dot (toJSVal q1) (toJSVal q2)
+
+  -- | Conjugate and normalize a quaternion
+  inverse :: o -> Three ()
+  inverse = thr_inverse . toJSVal
+
+  -- | The length of a quaternion as a 4-D vector
+  qLength :: o -> Three Double
+  qLength = thr_qLength . toJSVal
+
+  -- | The length of a quaternion as a 4-D vector, squared
+  --
+  -- This is useful if you want to compare lengths, as it saves
+  -- two square root calculations for the comparison
+  qLengthSq :: o -> Three Double
+  qLengthSq = thr_qLengthSq . toJSVal
+
+  -- | Normalize a quaternion (so that it has length 1)
+  qNormalize :: o -> Three ()
+  qNormalize = thr_qNormalize . toJSVal
+
+  -- | Multiply this quaternion by another and put the result in this one
+  qMultiply :: o -> o -> Three ()
+  qMultiply q o = thr_qMultiply (toJSVal q) (toJSVal o)
+
+  -- | Set this quaternion to be the product of two others
+  multiplyQuaternions :: o -> o -> o -> Three ()
+  multiplyQuaternions q r o = thr_multiplyQuaternions (toJSVal q) (toJSVal r) (toJSVal o)
+
+  -- | Multiply another quaternion by this one and put the result in this one
+  premultiply :: o -> o -> Three ()
+  premultiply q o = thr_premultiply (toJSVal q) (toJSVal o)
+
+  -- | Move this quaternion toward the given one by a specified amount (0 to 1)
+  slerp :: o -> Double -> o -> Three ()
+  slerp q t o = thr_slerp (toJSVal q) t (toJSVal o)
+
+  -- | Set all four elements of the quaternion at once: x y z w
+  setQuaternion :: Double -> Double -> Double -> Double -> o -> Three ()
+  setQuaternion x y z w o = thr_setQuaternion x y z w (toJSVal o)
+
+  -- | Set this quaternion equivalent to the given rotations around the three axes
+  -- (Euler rotation)
+  setFromEuler :: TEuler -> o -> Three ()
+  setFromEuler e o = do
+    re <- mkEuler e
+    thr_setFromEuler (toJSVal re) (toJSVal o)
+
+  -- | Set this quaternion equivalent to the rotation part of this matrix
+  setFromRotationMatrix :: Matrix4 -> o -> Three ()
+  setFromRotationMatrix m o = thr_setFromRotationMatrix (toJSVal m) (toJSVal o)
+
+  -- | Set this quaternion so that it rotates one vector to the other
+  setFromUnitVectors :: NormalVector -> NormalVector -> o -> Three ()
+  setFromUnitVectors v1 v2 o = thr_setFromUnitVectors (toJSVal v1) (toJSVal v2) (toJSVal o)
+
+instance IsQuaternion Quaternion
+
+foreign import javascript unsafe "($1)['conjugate']()"
+  thr_conjugate :: JSVal -> Three ()
+
+foreign import javascript unsafe "($2)['dot']($1)"
+  thr_dot :: JSVal -> JSVal -> Three Double
+
+foreign import javascript unsafe "($1)['inverse']()" 
+  thr_inverse :: JSVal -> Three ()
+
+foreign import javascript unsafe "($1)['length']()"
+  thr_qLength :: JSVal -> Three Double
+
+foreign import javascript unsafe "($1)['lengthSq']()"
+  thr_qLengthSq :: JSVal -> Three Double
+
+foreign import javascript unsafe "($1)['normalize']()"
+  thr_qNormalize :: JSVal -> Three ()
+
+foreign import javascript unsafe "($2)['multiply']($1)"
+  thr_qMultiply :: JSVal -> JSVal -> Three ()
+
+foreign import javascript unsafe "($3)['multiplyQuaternions']($1, $2)"
+  thr_multiplyQuaternions :: JSVal -> JSVal -> JSVal -> Three ()
+
+foreign import javascript unsafe "($2)['premultiply']($1)"
+  thr_premultiply :: JSVal -> JSVal -> Three ()
+
+foreign import javascript unsafe "($3)['slerp']($1, $2)"
+  thr_slerp :: JSVal -> Double -> JSVal -> Three ()
+
+foreign import javascript unsafe "($5)['set']($1, $2, $3, $4)"
+  thr_setQuaternion :: Double -> Double -> Double -> Double -> JSVal -> Three ()
+
+foreign import javascript unsafe "($3)['setFromAxisAngle']($1, $2)"
+  thr_setFromAxisAngle :: JSVal -> Double -> JSVal -> Three ()
+
+foreign import javascript unsafe "($2)['setFromEuler']($1)"
+  thr_setFromEuler :: JSVal -> JSVal -> Three ()
+
+foreign import javascript unsafe "($2)['setFromRotationMatrix']($1)"
+  thr_setFromRotationMatrix :: JSVal -> JSVal -> Three ()
+
+foreign import javascript unsafe "($3)['setFromUnitVectors']($1, $2)"
+  thr_setFromUnitVectors :: JSVal -> JSVal -> JSVal -> Three ()
+

--- a/src/GHCJS/Three/Texture.hs
+++ b/src/GHCJS/Three/Texture.hs
@@ -8,7 +8,7 @@ import GHCJS.Types
 import GHCJS.Foreign.Callback
 import GHCJS.Concurrent
 
-import GHCJS.DOM.Types
+import GHCJS.DOM.Types        hiding (toJSVal, fromJSVal)
 
 import GHCJS.Three.Monad
 import GHCJS.Three.Disposable

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,33 +1,19 @@
 flags: {}
 packages:
 - '.'
-- '../ghcjs-dom'
 extra-deps:
-- ghcjs-dom-0.2.2.0
-- AC-Vector-2.3.2
-- data-default-0.5.3
-- lens-4.13.2.1
-- base-orphans-0.5.3
-- bifunctors-5.2.1
-- comonad-5
-- contravariant-1.4
-- data-default-class-0.0.1
-- data-default-instances-base-0.0.1
-- data-default-instances-containers-0.0.1
-- data-default-instances-dlist-0.0.1
-- data-default-instances-old-locale-0.0.1
-- distributive-0.5.0.2
-- exceptions-0.8.2.1
-- free-4.12.4
-- kan-extensions-5.0.1
-- profunctors-5.2
-- reflection-2.1.2
-- semigroupoids-5.0.1
-- semigroups-0.18.1
-- tagged-0.8.3
-- transformers-compat-0.5.1.4
-- void-0.7.1
-- StateVar-1.1.0.3
-- adjunctions-4.3
-- prelude-extras-0.4.0.3
-resolver: ghcjs-0.2.0_ghc-7.10.2
+- ghcjs-dom-0.9.0.0
+- ghcjs-dom-jsffi-0.9.0.0
+
+resolver: lts-7.19
+compiler: ghcjs-0.2.1.9007019_ghc-8.0.1
+compiler-check: match-exact
+
+setup-info:
+  ghcjs:
+    source:
+      ghcjs-0.2.1.9007019_ghc-8.0.1:
+           url: http://ghcjs.tolysz.org/ghc-8.0-2017-02-05-lts-7.19-9007019.tar.gz
+           sha1: d2cfc25f9cda32a25a87d9af68891b2186ee52f9
+
+


### PR DESCRIPTION
This PR adds support for three.js quaternions to ghcjs-three.

* The new module `GHCJS.Three.Quaternion` wraps most operations on quaternions provided by Three.js
* The module `GHCJS.Three.HasXYZ` has an added `HasW` class to support the 4th element of quaternions in a way compatible with vectors
* The module `GHCJS.Three.Object3D` adds two class methods to support direct access to an object's rotational quaternion

All of these are in 9cdec22, which could be rebased onto master.

Two other commits contain changes I had to make to get ghcjs-three building, since the stack.yaml in the master branch specifies the compiler but no installation information. 